### PR TITLE
PHO-136: Use .cancel style for the cancel button

### DIFF
--- a/Photobook/Controllers/PhotobookViewController.swift
+++ b/Photobook/Controllers/PhotobookViewController.swift
@@ -196,7 +196,7 @@ class PhotobookViewController: UIViewController, PhotobookNavigationBarDelegate 
             }))
         }
         
-        alertController.addAction(UIAlertAction(title: CommonLocalizedStrings.cancel, style: .default, handler: nil))
+        alertController.addAction(UIAlertAction(title: CommonLocalizedStrings.cancel, style: .cancel, handler: nil))
         
         present(alertController, animated: true, completion: nil)
     }


### PR DESCRIPTION
The mentions that the options should be left-aligned and that there should be a checkmark next to the selected option. There's no way to do that unless we go full custom for this action sheet, which I don't think was the intention since the design is so close to the stock UIAlertController.