### PR TITLE
Fixed order cancel completion be called twice issue

### DIFF
--- a/Photobook/Model/Order/OrderManager.swift
+++ b/Photobook/Model/Order/OrderManager.swift
@@ -243,6 +243,7 @@ class OrderManager {
     func cancelProcessing(completion: @escaping () -> Void) {
         if !isProcessingOrder {
             completion()
+            return
         }
         
         if isCancelling {


### PR DESCRIPTION
## Description

I found out that this method's `completion` is being called twice when dismissing receipt page.
I think if there is not processing order then just call completion and return it.

```swift
class OrderManager {
     ...
     func cancelProcessing(completion: @escaping () -> Void)
}
```
