### PR TITLE
Updated AssetsNotificationName.albumsWereUpdated value

### DIFF
--- a/PhotobookSDK/PhotobookSDK.swift
+++ b/PhotobookSDK/PhotobookSDK.swift
@@ -31,7 +31,7 @@ import UIKit
 import SDWebImage
 
 struct AssetsNotificationName {
-    static let albumsWereUpdated = Notification.Name("ly.kite.photobook.albumsWereUpdatedNotificationName")
+    static let albumsWereUpdated = Notification.Name("ly.kite.photobook.sdk.albumsWereUpdatedNotificationName")
 }
 
 @objc public class AlbumChange: NSObject {


### PR DESCRIPTION
# Description
Fixed album crash http://crashes.to/s/f898cdb572f
## Steps
1. Select `Browse` tab
2. Select `Camera Roll`
3. Take screenshot and app will crash.

## Details
The crash is caused by album changes.
The collectionView was updated twice and it crashed at second time.
The root cause is because of two notifications have same name.
```swift
struct AssetsNotificationName {
    static let albumsWereUpdated = Notification.Name("ly.kite.photobook.albumsWereUpdatedNotificationName")
}
struct AlbumManagerNotificationName {
    static let albumsWereUpdated = Notification.Name("ly.kite.photobook.albumsWereUpdatedNotificationName")
}
``` 
And `PhotosAlbumManager` will trigger notifications when receiving photoLibraryDidChange event

```swift
    // PhotosAlbumManager
    func photoLibraryDidChange(_ changeInstance: PHChange) {
        // ...
       // L224-L227
       dispatchGroup.notify(queue: DispatchQueue.main, execute: {
            NotificationCenter.default.post(name: AlbumManagerNotificationName.albumsWereUpdated, object: albumChanges)
            PhotobookSDK.shared.albumsWereUpdated(albumChanges)
       })      
    }          

    // PhotobookSDK
    @objc public func albumsWereUpdated(_ changes: [AlbumChange]) {
        NotificationCenter.default.post(name: AssetsNotificationName.albumsWereUpdated, object: changes)
    }

```
