### PR TITLE
Fixed story images ordering

### DIFF
--- a/App/Model/Stories/StoriesManager.swift
+++ b/App/Model/Stories/StoriesManager.swift
@@ -155,6 +155,7 @@ class StoriesManager: NSObject {
             moments.enumerateObjects { (collection: PHAssetCollection, index: Int,  stop: UnsafeMutablePointer<ObjCBool>) in
                 //only use images
                 let fetchOptions = PHFetchOptions()
+                fetchOptions.sortDescriptors = [ NSSortDescriptor(key: "creationDate", ascending: false) ]
                 fetchOptions.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
                 guard let filteredCollection = welf?.assetManager.fetchAssets(in: collection, options: fetchOptions) else { return }
                 

--- a/App/Model/Stories/Story.swift
+++ b/App/Model/Stories/Story.swift
@@ -185,7 +185,7 @@ extension Story: Album {
     }
     
     func coverAsset(completionHandler: @escaping (PhotobookAsset?) -> Void) {
-        collectionForCoverPhoto.coverAsset(useFirstImageInCollection: true, completionHandler: completionHandler)
+        collectionForCoverPhoto.coverAsset(useFirstImageInCollection: false, completionHandler: completionHandler)
     }
     
     func loadNextBatchOfAssets(completionHandler: ((Error?) -> Void)?) {}

--- a/App/Model/Stories/Story.swift
+++ b/App/Model/Stories/Story.swift
@@ -32,11 +32,18 @@ import Photobook
 
 protocol CollectionManager {
     func fetchMoments(inMomentList collectionList: PHCollectionList) -> PHFetchResult<PHAssetCollection>
+    func fetchMoments(inMomentList collectionList: PHCollectionList, options: PHFetchOptions?) -> PHFetchResult<PHAssetCollection>
 }
 
 class DefaultCollectionManager: CollectionManager {
     func fetchMoments(inMomentList collectionList: PHCollectionList) -> PHFetchResult<PHAssetCollection> {
-        return PHAssetCollection.fetchMoments(inMomentList: collectionList, options: PHFetchOptions())
+        let options = PHFetchOptions()
+        options.sortDescriptors = [ NSSortDescriptor(key: "startDate", ascending: false) ]
+        return fetchMoments(inMomentList: collectionList, options: options)
+    }
+
+    func fetchMoments(inMomentList collectionList: PHCollectionList, options: PHFetchOptions?) -> PHFetchResult<PHAssetCollection> {
+        return PHAssetCollection.fetchMoments(inMomentList: collectionList, options: options)
     }
 }
 
@@ -162,13 +169,11 @@ extension Story: Album {
         fetchOptions.wantsIncrementalChangeDetails = false
         fetchOptions.includeHiddenAssets = false
         fetchOptions.includeAllBurstAssets = false
+        fetchOptions.sortDescriptors = [ NSSortDescriptor(key: "creationDate", ascending: false) ]
+        fetchOptions.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue) // Only images
         
         let moments = collectionManager.fetchMoments(inMomentList: collectionList)
         moments.enumerateObjects { (collection: PHAssetCollection, index: Int,  stop: UnsafeMutablePointer<ObjCBool>) in
-            
-            fetchOptions.sortDescriptors = [ NSSortDescriptor(key: "creationDate", ascending: true) ]
-            fetchOptions.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue) // Only images
-            
             let fetchedAssets = self.assetsManager.fetchAssets(in: collection, options: fetchOptions)
             fetchedAssets.enumerateObjects({ (asset, _, _) in
                 let photobookAsset = PhotobookAsset(withPHAsset: asset, albumIdentifier: self.identifier)


### PR DESCRIPTION
# Description

The story image ordering is from oldest to newest.
It should be newest to oldest to match other photo pickers behavior.